### PR TITLE
Ignore moved plots

### DIFF
--- a/plot_util.py
+++ b/plot_util.py
@@ -56,8 +56,11 @@ def list_k32_plots(d):
     for plot in os.listdir(d):
         if re.match(r'^plot-k32-.*plot$', plot):
             plot = os.path.join(d, plot)
-            if os.stat(plot).st_size > (0.95 * get_k32_plotsize()):
-                plots.append(plot)
+            try:
+                if os.stat(plot).st_size > (0.95 * get_k32_plotsize()):
+                    plots.append(plot)
+            except Exception:
+                'file not found'
     
     return plots
 


### PR DESCRIPTION
Fix for FileNotFound exception, or other I/O errors while generating reports.

Traceback (most recent call last):
  File "reporting.py", line 157, in dst_dir_report
    dir_plots = plot_util.list_k32_plots(d)
  File "plot_util.py", line 59, in list_k32_plots
    if os.stat(plot).st_size > (0.95 * get_k32_plotsize()):
FileNotFoundError: [WinError 2] The system cannot find the file specified: x.plot